### PR TITLE
Ensure blog preview shows latest posts

### DIFF
--- a/src/components/blogPreview/BlogPreview.jsx
+++ b/src/components/blogPreview/BlogPreview.jsx
@@ -7,6 +7,10 @@ const BlogPreview = () => {
 
   let navigate = useNavigate()
 
+  const recentPosts = [...Data]
+    .sort((a, b) => b.id - a.id)
+    .slice(0, 3)
+
   return (
     <section id="blogPreview">
     
@@ -18,7 +22,7 @@ const BlogPreview = () => {
 
       {
 
-        Data.slice(-3).map(({id, image, title, github, read}) => {
+        recentPosts.map(({id, image, title, github, read}) => {
 
           return(
             <article key={id} className="blogPreview__item">


### PR DESCRIPTION
## Summary
- sort the blog post data by newest before building the preview list
- show the first three items from the sorted data to ensure the latest posts appear

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10e0f7f44832aaf71efa7b0df0916